### PR TITLE
Remove hide() call in qt canvas class

### DIFF
--- a/src/topsy/canvas/qt/__init__.py
+++ b/src/topsy/canvas/qt/__init__.py
@@ -35,7 +35,6 @@ class VisualizerCanvas(VisualizerCanvasBase, RenderCanvas):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._all_instances.append(self)
-        self.hide()
 
         self._toolbar = QtWidgets.QToolBar()
         self._toolbar.setIconSize(QtCore.QSize(16, 16))


### PR DESCRIPTION
This removes a QT hide() call which seems to prevent the topsy window from appearing when running on Ubuntu (issue #24)
