### PR TITLE
Minimal changes to access remote snapshots

### DIFF
--- a/src/topsy/__init__.py
+++ b/src/topsy/__init__.py
@@ -48,6 +48,7 @@ def parse_args(args=None):
                             metavar=("_"),
                             default=None, type=float)
     argparser.add_argument('--hdfstream-server', type=str, help="Read a SWIFT snapshot from the specified server")
+    argparser.add_argument('--hdfstream-user', type=str, help="User name for the hdfstream service")
 
     if args is None:
         args = sys.argv[1:]
@@ -91,7 +92,7 @@ def main():
                     particle=args.particle, tile=args.tile,
                     sphere_radius=args.load_sphere[0] if args.load_sphere is not None else None,
                     sphere_center=tuple(args.load_sphere[1:]) if args.load_sphere is not None and len(args.load_sphere) == 4 else None,
-                    render_mode=args.render_mode, hdfstream_server=args.hdfstream_server)
+                    render_mode=args.render_mode, hdfstream_server=args.hdfstream_server, hdfstream_user=args.hdfstream_user)
         vis.quantity_name = args.quantity
         vis.canvas.show()
 
@@ -110,7 +111,8 @@ def topsy(snapshot: pynbody.snapshot.SimSnap, quantity: str | None = None, param
 def load(filename: str, center: str = "none", particle: str = "gas", 
          resolution: int = config.DEFAULT_RESOLUTION, tile: bool = False,
          sphere_radius: float | None = None, sphere_center: tuple[float, float, float] | None = None,
-         render_mode: str = None, hdfstream_server: str | None = None) -> Visualizer:
+         render_mode: str = None, hdfstream_server: str | None = None,
+         hdfstream_user: str | None = None) -> Visualizer:
     """
     Load a simulation file (currently using pynbody) and return a visualizer object.
 
@@ -165,7 +167,7 @@ def load(filename: str, center: str = "none", particle: str = "gas",
         import pynbody
         if hdfstream_server is not None:
             loader_class = loader.PynbodyRemoteDataLoader
-            server_args = (hdfstream_server,)
+            server_args = (hdfstream_server, hdfstream_user)
         else:
             loader_class = loader.PynbodyDataLoader
             server_args = ()

--- a/src/topsy/loader.py
+++ b/src/topsy/loader.py
@@ -216,7 +216,7 @@ class PynbodyRemoteDataLoader(PynbodyDataInMemory):
 
     _name_smooth_array = 'topsy_smooth'
 
-    def __init__(self, device: wgpu.GPUDevice, server: str, filename: str, center: str, particle: str,
+    def __init__(self, device: wgpu.GPUDevice, server: str, user: str, filename: str, center: str, particle: str,
                  take_region: Optional[pynbody.filt.Filter] = None):
 
         logger.info(f"Data filename = {filename}, center = {center}, particle = {particle}")
@@ -224,9 +224,9 @@ class PynbodyRemoteDataLoader(PynbodyDataInMemory):
         # Currently only Swift snapshots are supported
         import pynbody.snapshot.remote_swift as rs
         if take_region is None:
-            snapshot = rs.RemoteSwiftSnap(filename, server=server)
+            snapshot = rs.RemoteSwiftSnap(filename, server=server, user=user)
         else:
-            snapshot = rs.RemoteSwiftSnap(filename, server=server, take_region=take_region)
+            snapshot = rs.RemoteSwiftSnap(filename, server=server, user=user, take_region=take_region)
 
         snapshot.physical_units()
         self.filename = filename


### PR DESCRIPTION
This modifies topsy to read particle data using the RemoteSwiftSnap class from https://github.com/pynbody/pynbody/pull/924 .

I've put a SWIFT example snapshot on the server for testing. E.g.
```
topsy --hdfstream-server=https://dataweb.cosma.dur.ac.uk:8443/hdfstream SWIFT/examples/EAGLE_low_z/EAGLE_100/eagle_0000.hdf5 --load-sphere 5 50 50 50
```
If the server flag is present then the filename is taken to be a location on the server.

I'll make this a draft pull request for now in case it's affected by changes to the pynbody pull request.